### PR TITLE
Add CORS configuration and support for YouTube short URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import sys
 import traceback
 import uvicorn
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Dict, Any
 from youtube_transcript_api import YouTubeTranscriptApi
@@ -77,6 +78,15 @@ app = FastAPI(
     title=API_TITLE,
     description=API_DESCRIPTION,
     version=API_VERSION,
+)
+
+# CORSミドルウェアの設定を追加
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 

--- a/main.py
+++ b/main.py
@@ -49,10 +49,15 @@ class YouTubeTranscriptService:
     def extract_video_id(url_or_id: str) -> str:
         '''
         概要: URLまたはビデオIDからビデオIDを抽出 \n
-        用途: 完全なYouTube URLが提供された場合にビデオIDを取得する
+        用途: 完全なYouTube URLまたは短縮URLが提供された場合にビデオIDを取得する
         '''
-        if url_or_id.startswith(YOUTUBE_URL_PREFIX):
+        # youtu.be形式のURLに対応
+        if "youtu.be" in url_or_id:
+            return url_or_id.split("youtu.be/")[1].split("?")[0]
+        # 通常のYouTube URL
+        elif "youtube.com/watch" in url_or_id:
             return url_or_id.split("v=")[1].split("&")[0]
+        # すでにビデオIDの場合
         return url_or_id
 
     @staticmethod

--- a/main.py
+++ b/main.py
@@ -121,6 +121,6 @@ try:
 except Exception as e:
     error_trace = get_exception_trace()
     print("エラーが発生しました:")
-    for line in error_trace:
+    for line in error_trace.splitlines():
         print(line)
     sys.exit(1)


### PR DESCRIPTION
# 🔧 CORSの設定追加とYouTube短縮URL対応

## 変更内容 | Changes

### CORS設定の追加 | CORS Configuration
- FastAPIにCORSミドルウェアを追加
- フロントエンド（localhost:3000）からのリクエストを許可
- OPTIONSメソッドのプリフライトリクエストに対応

### YouTube URL処理の改善 | YouTube URL Handling
- 短縮URL（youtu.be）形式に対応
- クエリパラメータの適切な除去処理を追加
- URL抽出ロジックの堅牢性を向上

## 動作確認済み | Tested URLs
以下のURL形式での文字起こし取得が可能になりました：
- ✅ 通常のYouTube URL: `https://www.youtube.com/watch?v=XXXX`
- ✅ 短縮URL: `https://youtu.be/XXXX`
- ✅ ビデオID直接指定: `XXXX`

## テスト方法 | Testing Steps
1. バックエンドサーバーを起動: `python main.py`
2. フロントエンドを起動: `cd frontend && npm run dev`
3. 各形式のURLで文字起こし取得をテスト

