### PR TITLE
Separate chat history for transcripts and summaries

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -19,8 +19,9 @@ export default function Home() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError('');
     setTranscript([]);
+    setSummary(''); // 要約をリセット
+    setError('');
     setIsLoading(true);
 
     try {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -287,7 +287,7 @@ export default function Home() {
         </div>
 
         {/* チャットサイドバー */}
-        <div className="w-96 bg-white shadow rounded-lg overflow-hidden flex flex-col">
+        <div className="w-96 bg-white shadow rounded-lg overflow-hidden flex flex-col h-[calc(100vh-12rem)]">
           <div className="p-4 bg-gray-50 border-b border-gray-200">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-lg font-medium text-gray-900">チャット</h2>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -177,7 +177,7 @@ export default function Home() {
                   <input
                     type="text"
                     id="videoUrl"
-                    className="flex-1 rounded-l-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 p-2 border"
+                    className="flex-1 rounded-l-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 p-2 border text-black"
                     placeholder="https://www.youtube.com/watch?v=xxxx または xxxx"
                     value={videoUrl}
                     onChange={(e) => setVideoUrl(e.target.value)}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,7 +14,8 @@ export default function Home() {
   // チャット関連の状態
   const [chatType, setChatType] = useState('transcript');
   const [chatMessage, setChatMessage] = useState('');
-  const [chatMessages, setChatMessages] = useState([]);
+  const [transcriptChatMessages, setTranscriptChatMessages] = useState([]);
+  const [summaryChatMessages, setSummaryChatMessages] = useState([]);
   const [isChatLoading, setIsChatLoading] = useState(false);
 
   const handleSubmit = async (e) => {
@@ -89,7 +90,11 @@ export default function Home() {
     if (!chatMessage.trim() || isChatLoading) return;
 
     const newMessage = { type: 'user', content: chatMessage };
-    setChatMessages(prev => [...prev, newMessage]);
+    if (chatType === 'transcript') {
+      setTranscriptChatMessages(prev => [...prev, newMessage]);
+    } else {
+      setSummaryChatMessages(prev => [...prev, newMessage]);
+    }
     setChatMessage('');
     setIsChatLoading(true);
 
@@ -116,7 +121,12 @@ export default function Home() {
       }
 
       const data = await response.json();
-      setChatMessages(prev => [...prev, { type: 'ai', content: data.response }]);
+      const aiMessage = { type: 'ai', content: data.response };
+      if (chatType === 'transcript') {
+        setTranscriptChatMessages(prev => [...prev, aiMessage]);
+      } else {
+        setSummaryChatMessages(prev => [...prev, aiMessage]);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : '予期せぬエラーが発生しました');
     } finally {
@@ -307,7 +317,7 @@ export default function Home() {
           </div>
 
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
-            {chatMessages.map((msg, index) => (
+            {(chatType === 'transcript' ? transcriptChatMessages : summaryChatMessages).map((msg, index) => (
               <div
                 key={index}
                 className={`flex ${
@@ -315,13 +325,18 @@ export default function Home() {
                 }`}
               >
                 <div
-                  className={`max-w-[80%] rounded-lg p-3 ${
+                  className={`max-w-[80%] rounded-lg p-3 relative ${
                     msg.type === 'user'
                       ? 'bg-blue-600 text-white'
                       : 'bg-gray-100 text-gray-900'
                   }`}
                 >
                   {msg.content}
+                  {msg.type === 'user' && (
+                    <span className="absolute -top-2 right-2 text-xs text-gray-500 bg-white px-1 rounded">
+                      {chatType === 'transcript' ? '文字起こし' : '要約'}
+                    </span>
+                  )}
                 </div>
               </div>
             ))}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -348,7 +348,7 @@ export default function Home() {
                     ? "メッセージを入力..."
                     : "文字起こしまたは要約を取得してください"
                 }
-                className="flex-1 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50"
+                className="flex-1 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 text-black"
                 onKeyPress={(e) => {
                   if (e.key === 'Enter') {
                     handleSendMessage();


### PR DESCRIPTION
# UI調整

- 文字起こしとサマリーのチャット履歴を別々に管理し、種類を切り替えてもそれぞれの履歴が保持されるように変更

![image](https://github.com/user-attachments/assets/8f680800-ee83-4dae-95b4-07db4bfdfd9b)
![image](https://github.com/user-attachments/assets/48a2c118-21b2-4a78-8e76-02546516c5c0)


- 新しい文字起こしをリクエストする際にサマリーをリセットし、より見やすくするためにチャット入力テキストの色を調整


- チャットサイドバーの高さを文字起こし結果に依存しないように修正

![image](https://github.com/user-attachments/assets/b639d7ab-b3f0-4304-9a48-3c3be7047d14)


Implement separate management of chat history for transcripts and summaries, ensuring that switching between types retains the respective histories. Reset the summary when requesting new transcriptions and adjust the chat input text color for better visibility. Additionally, fix the chat sidebar height to be independent of the transcription results.

