### PR TITLE
Connect to Google Cloud SQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /agents/__pycache__
 /credentials
 /docs
+/database/__pycache__
 .env

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ npm install
 npm run dev
 ```
 
+### Cloud SQL接続
+
+1. Cloud SQL Proxyのインストール
+2. Cloud SQL Admin APIの有効化
+   - GCPコンソールで有効化: https://console.developers.google.com/apis/api/sqladmin.googleapis.com/overview?project=youtube-content-processor2
+3. ローカルMySQLサーバーが実行中の場合は停止（ポート3306が使用中の場合）
+   - 実行中のプロセス確認: `netstat -ano | findstr :3306`
+   - プロセスID確認: `tasklist | findstr <PID>`
+   - サービス停止: `taskkill /F /PID <PID>` または services.mscから停止
+4. Cloud SQL Proxyの実行
+   ```bash
+   cloud-sql-proxy youtube-content-processor2:asia-northeast1:youtube-content-processor2 --port=3306
+   ```
+   - 実行中はコマンドプロンプトを閉じないでください
+
 ## 使い方
 
 1. バックエンド(http://localhost:8000)とフロントエンド(http://localhost:3000)を起動

--- a/README.md
+++ b/README.md
@@ -4,31 +4,73 @@
 
 - YouTube動画IDから文字起こしデータを取得
 - URLからビデオIDを自動抽出
-- GPT-4を使用した文字起こしの要約機能（OpenAI API使用）
+- GPT-4.1-nanoを使用した文字起こしの要約機能（OpenAI API使用）
 - チャット機能を追加して、文字起こしや要約に基づいた質問を処理
 - TypeScript + Next.jsのモダンなUI
+- Cloud SQL（MySQL）を使用したデータベース保存機能
+- Google Cloud Storage（GCS）を使用した要約データの保存機能
+- Docker対応（バックエンド・フロントエンド両方）
 
 ## プロジェクト構造
 
 ```
 youtube-content-processor2/
-├── main.py               # FastAPIサーバー（API実装）
+├── main.py                # FastAPIサーバー（API実装）
 ├── agents/
-│   └── summarizer.py    # 要約処理（GPT-4）
+│   └── summarizer.py      # 要約処理（GPT-4.1-nano）
+├── database/
+│   ├── __init__.py        # データベースパッケージ初期化
+│   ├── db_models.py       # データベースモデル定義
+│   └── db_service.py      # データベース操作サービス
+├── dev_tools/
+│   ├── check_bucket_iam.py      # GCS権限チェックツール
+│   └── credential_test.py       # 認証情報テストツール
 ├── frontend/          
-│   └── src/           
-│       └── app/      
-│           ├── globals.css
-│           ├── layout.tsx
-│           └── page.tsx
+│   ├── src/           
+│   │   └── app/      
+│   │       ├── globals.css
+│   │       ├── layout.tsx
+│   │       └── page.tsx
+│   ├── public/             # 静的アセット
+│   ├── Dockerfile          # フロントエンド用Docker設定
+│   └── package.json        # フロントエンド依存関係
+├── Dockerfile             # バックエンド用Docker設定
+├── requirements.txt       # Python依存パッケージ
 └── README.md
 ```
 
 ## セットアップ
 
+### 環境変数の設定
+
+`.env`ファイルを作成し、以下の環境変数を設定してください：
+
+```
+# OpenAI API設定
+OPENAI_API_KEY=your_openai_api_key
+
+# YouTube API設定
+YouTube_API_KEY=your_youtube_api_key
+
+# データベース設定
+DB_USER=your_db_user
+DB_PASS=your_db_password
+DB_NAME=your_db_name
+DB_HOST=your_db_host
+DB_PORT=3306
+INSTANCE_CONNECTION_NAME=your_cloud_sql_instance_connection_name
+
+# Google Cloud Storage設定
+GCS_BUCKET_NAME=your_gcs_bucket_name
+GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credentials.json
+```
+
 ### バックエンド
 
 ```bash
+# 依存関係のインストール
+pip install -r requirements.txt
+
 # 実行
 python main.py
 ```
@@ -56,6 +98,33 @@ npm run dev
    ```
    - 実行中はコマンドプロンプトを閉じないでください
 
+### Google Cloud Storage（GCS）設定
+
+1. GCSバケットの作成（存在しない場合）
+2. サービスアカウントに適切な権限を付与:
+   - Storage オブジェクト閲覧者 (roles/storage.objectViewer)
+   - Storage オブジェクト作成者 (roles/storage.objectCreator)
+3. 権限設定をテストするには:
+   ```bash
+   python dev_tools/check_bucket_iam.py
+   python dev_tools/credential_test.py
+   ```
+
+### Dockerを使用した実行
+
+バックエンド:
+```bash
+docker build -t youtube-content-processor-backend .
+docker run -p 8000:8000 --env-file .env youtube-content-processor-backend
+```
+
+フロントエンド:
+```bash
+cd frontend
+docker build -t youtube-content-processor-frontend .
+docker run -p 3000:3000 youtube-content-processor-frontend
+```
+
 ## 使い方
 
 1. バックエンド(http://localhost:8000)とフロントエンド(http://localhost:3000)を起動
@@ -64,39 +133,60 @@ npm run dev
 4. 「文字起こし取得」をクリックして字幕を取得
    - 日本語・英語の両方を自動で試行
 5. 文字起こしが表示されたら「要約取得」をクリックして要約を生成
-6. **新機能: チャットサイドバー**を利用して、文字起こしや要約に基づいた質問を行う
+   - 要約データはデータベースとGCSに保存され、再度同じ動画の要約を要求した場合はキャッシュから読み込まれます
+6. **チャットサイドバー**を利用して、文字起こしや要約に基づいた質問を行う
    - 入力フィールドに質問を入力し、送信ボタンをクリック
+   - 「文字起こし」「要約」いずれかのモードで質問できます
 
-## 新機能: チャット機能
-
-- **エンドポイント:** `/chat/`
-- **使用例:**
-  - 質問内容を送信すると、文字起こしまたは要約に基づいて回答が返されます。
-  - フロントエンドのチャットUIには、ユーザーとAIのメッセージが表示されます。
-
-## 環境要件
+## 技術スタック詳細
 
 ### バックエンド
 
-- Python 3.12以上
-- 依存パッケージ:
-  - fastapi
-  - uvicorn
-  - youtube-transcript-api
-  - langchain-openai
-  - pydantic
-  - python-dotenv
-- 環境変数:
-  - OPENAI_API_KEY: OpenAI APIキー
-  - YouTube_API_KEY: YouTube Data API v3のAPIキー
+- Python 3.12.9
+- FastAPI: RESTful APIフレームワーク
+- youtube-transcript-api: YouTube字幕取得ライブラリ
+- langchain + OpenAI: GPT-4.1-nanoを使用した要約・チャット処理
+- SQLAlchemy: データベースORM
+- Google Cloud Storage: 要約データJSON保存
+- MySQL（Cloud SQL）: 要約データの永続化
 
 ### フロントエンド
 
-- Node.js 20以上
-- 主要パッケージ:
-  - Next.js 14
-  - React 18
-  - TailwindCSS
+- Next.js 15.3.0: Reactフレームワーク
+- React 19.0.0: UIライブラリ
+- TypeScript: 型安全な開発
+- TailwindCSS 4: ユーティリティファーストCSSフレームワーク
+- ESLint 9: コード品質管理
+
+## 要約機能の詳細
+
+`agents/summarizer.py`では、GPT-4.1-nanoを使用して文字起こしテキストから構造化された要約を生成します。要約は以下の要素を含みます：
+
+- **サブタイトル**: 動画の主題を表す簡潔なタイトル
+- **概要**: 動画の内容に関する簡潔な要約
+- **主要トピック**: 動画で扱われる3-5個の主要トピック
+- **重要ポイント**: 3-5個の重要ポイントとその説明
+- **キーワード**: 動画の内容を表す5-8個のキーワード
+- **アクションアイテム**: 視聴者が実践できる2-3個のアクション
+
+要約生成プロセスでは、Chain-of-Thoughtアプローチを採用し、分析ステップと要約ステップの2段階で処理を行い、より高品質な要約を実現しています。
+
+## チャット機能の詳細
+
+- **エンドポイント:** `/chat/`
+- **機能**: 文字起こしまたは要約に基づいた質問応答
+- **使用モデル**: GPT-4.1-nano
+- **インターフェース**: サイドバーUIで文字起こし/要約のコンテキストを切り替え可能
+
+## データ永続化
+
+1. **Cloud SQL（MySQL）**
+   - `VideoSummary`テーブルに構造化された要約データを保存
+   - 再要求時に高速に取得するためのキャッシュとして機能
+
+2. **Google Cloud Storage（GCS）**
+   - 要約データをJSON形式で保存
+   - タイムスタンプとUUIDを含むユニークなファイル名で管理
 
 ## API仕様
 
@@ -149,7 +239,8 @@ npm run dev
 ```json
 {
   "video_id": "dQw4w9WgXcQ",
-  "summary": "要約テキスト"
+  "summary": "要約テキスト（JSON形式）",
+  "gcs_path": "gs://bucket-name/summaries/video_id_timestamp_uuid.json"
 }
 ```
 
@@ -159,6 +250,7 @@ npm run dev
   "detail": "指定された言語の文字起こしが利用できません"
 }
 ```
+
 ### チャット: POST /chat/
 
 #### リクエスト
@@ -182,3 +274,32 @@ npm run dev
 - OpenAI APIキーの設定が必須（環境変数：OPENAI_API_KEY）
 - 文字起こしの取得には対象動画が字幕を持っている必要あり
 - プロダクション環境では適切なCORS設定が必要（現在はlocalhost:3000のみ許可）
+- Cloud SQLとGCSの適切な権限設定が必要
+- フロントエンドをカスタマイズする場合は、APIエンドポイントのURLを適宜変更
+
+## トラブルシューティング
+
+1. **Cloud SQL接続エラー**
+   - Cloud SQL Proxyが正しく実行されているか確認
+   - 環境変数が正しく設定されているか確認
+   - ファイアウォール設定を確認
+
+2. **GCS保存エラー**
+   - サービスアカウントの権限を確認（`dev_tools/check_bucket_iam.py`を使用）
+   - `GOOGLE_APPLICATION_CREDENTIALS`が正しく設定されているか確認
+
+3. **文字起こし取得エラー**
+   - 対象動画に字幕が存在するか確認
+   - YouTube API Keyの有効性を確認
+
+4. **要約生成エラー**
+   - OpenAI APIキーの有効性と利用制限を確認
+   - 大量のトークンを処理する場合は長い応答時間に注意
+
+5. **フロントエンド接続エラー**
+   - バックエンドのCORS設定を確認
+   - APIエンドポイントURLが正しいか確認（デフォルトは`http://127.0.0.1:8000`）
+
+## ライセンスと著作権
+
+このアプリケーションはYouTubeコンテンツの個人的な視聴・学習を支援するために開発されています。動画コンテンツの著作権はYouTubeクリエイターに帰属します。文字起こしデータの取得と処理は、教育目的や個人利用の範囲内で行ってください。

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,5 @@
+# データベースパッケージの初期化
+from .db_models import create_tables, VideoSummary
+from .db_service import DatabaseService
+
+__all__ = ['create_tables', 'VideoSummary', 'DatabaseService']

--- a/database/db_models.py
+++ b/database/db_models.py
@@ -1,0 +1,71 @@
+from sqlalchemy import Column, String, Text, DateTime, Integer, create_engine, JSON
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+import os
+from datetime import datetime
+from dotenv import load_dotenv
+
+# .envファイルからの環境変数読み込み
+load_dotenv()
+
+# データベース接続情報
+DB_USER = os.getenv("DB_USER")
+DB_PASS = os.getenv("DB_PASS")
+DB_NAME = os.getenv("DB_NAME")
+DB_HOST = os.getenv("DB_HOST")
+DB_PORT = os.getenv("DB_PORT", "3306")  # MySQLのデフォルトポート
+INSTANCE_CONNECTION_NAME = os.getenv("INSTANCE_CONNECTION_NAME")
+
+# 本番環境ではCloud SQL Proxy経由で接続
+if os.getenv("GAE_ENV", "").startswith("standard"):
+    # App Engineの場合、Unix socketを使用
+    db_socket_dir = os.getenv("DB_SOCKET_DIR", "/cloudsql")
+    cloud_sql_connection_name = INSTANCE_CONNECTION_NAME
+    pool_recycle = 90  # 90秒ごとに接続をリサイクル
+    pool_timeout = 30  # 接続プールからの取得タイムアウト
+    max_overflow = 10  # コネクションプールの最大オーバーフロー数
+    
+    db_url = f"mysql+pymysql://{DB_USER}:{DB_PASS}@/{DB_NAME}?unix_socket={db_socket_dir}/{cloud_sql_connection_name}"
+else:
+    # ローカル開発環境では直接接続
+    db_url = f"mysql+pymysql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+# データベースエンジンの作成
+engine = create_engine(
+    db_url, 
+    pool_recycle=90, 
+    pool_timeout=30,
+    pool_pre_ping=True
+)
+
+# セッションの作成
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# モデルのベースクラス
+Base = declarative_base()
+
+# 要約データモデル
+class VideoSummary(Base):
+    __tablename__ = "video_summaries"
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    video_id = Column(String(255), nullable=False, index=True)
+    video_title = Column(String(500))
+    video_description = Column(Text)
+    channel_title = Column(String(255))
+    channel_id = Column(String(255))
+    sub_title = Column(String(500))
+    overview = Column(Text)
+    main_topics = Column(JSON)  # MySQLではARRAYタイプがないためJSONを使用
+    keywords = Column(JSON)     # MySQLではARRAYタイプがないためJSONを使用
+    action_items = Column(JSON) # MySQLではARRAYタイプがないためJSONを使用
+    key_points = Column(JSON)   # 構造化データは保持
+    gcs_path = Column(String(500))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    
+    def __repr__(self):
+        return f"<VideoSummary(video_id='{self.video_id}', title='{self.video_title}')>"
+
+# データベーステーブルの作成
+def create_tables():
+    Base.metadata.create_all(bind=engine)

--- a/database/db_service.py
+++ b/database/db_service.py
@@ -1,0 +1,96 @@
+import json
+from sqlalchemy.exc import SQLAlchemyError
+from .db_models import SessionLocal, VideoSummary
+import traceback
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class DatabaseService:
+    """
+    概要: データベース操作を行うサービスクラス
+    用途: 要約データのDB保存と取得
+    """
+    
+    @staticmethod
+    def save_summary_to_db(video_id, summary_data, video_info, gcs_path=None):
+        """
+        概要: 要約データをデータベースに保存
+        用途: 生成された要約データをCloud SQLに格納
+        """
+        # セッションの開始
+        db = SessionLocal()
+        try:
+            # 要約データがJSON文字列の場合はパース
+            if isinstance(summary_data, str):
+                try:
+                    summary_json = json.loads(summary_data)
+                except json.JSONDecodeError:
+                    logger.error(f"JSONデコードエラー: {summary_data[:100]}...")
+                    return None
+            else:
+                summary_json = summary_data
+            
+            # データベースエントリの作成
+            db_summary = VideoSummary(
+                video_id=video_id,
+                video_title=video_info.get("title", ""),
+                video_description=video_info.get("description", ""),
+                channel_title=video_info.get("channelTitle", ""),
+                channel_id=video_info.get("channelId", ""),
+                sub_title=summary_json.get("sub_title", ""),
+                overview=summary_json.get("overview", ""),
+                main_topics=summary_json.get("main_topics", []),
+                keywords=summary_json.get("keywords", []),
+                action_items=summary_json.get("action_items", []),
+                key_points=summary_json.get("key_points", []),
+                gcs_path=gcs_path
+            )
+            
+            # データベースに追加とコミット
+            db.add(db_summary)
+            db.commit()
+            db.refresh(db_summary)
+            logger.info(f"データベースに要約を保存しました: video_id={video_id}, id={db_summary.id}")
+            return db_summary.id
+        except SQLAlchemyError as e:
+            db.rollback()
+            error_trace = traceback.format_exc()
+            logger.error(f"データベース保存エラー: {str(e)}\n{error_trace}")
+            return None
+        except Exception as e:
+            db.rollback()
+            error_trace = traceback.format_exc()
+            logger.error(f"予期せぬエラー: {str(e)}\n{error_trace}")
+            return None
+        finally:
+            db.close()
+    
+    @staticmethod
+    def get_summary_by_video_id(video_id):
+        """
+        概要: ビデオIDから要約データを取得
+        用途: 過去に保存した要約データの取得
+        """
+        db = SessionLocal()
+        try:
+            summary = db.query(VideoSummary).filter(VideoSummary.video_id == video_id).order_by(VideoSummary.created_at.desc()).first()
+            if summary:
+                # データベースのフィールドからJSONオブジェクトを再構築
+                summary_data = {
+                    "sub_title": summary.sub_title,
+                    "overview": summary.overview,
+                    "main_topics": summary.main_topics,
+                    "keywords": summary.keywords,
+                    "action_items": summary.action_items,
+                    "key_points": summary.key_points
+                }
+                # summary_dataプロパティを追加
+                summary.summary_data = summary_data
+            return summary
+        except Exception as e:
+            logger.error(f"要約取得エラー: {str(e)}")
+            return None
+        finally:
+            db.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ google-api-python-client>=2.0.0
 google-cloud-storage>=3.0.0
 python-dotenv>=1.0.0
 tiktoken>=0.9.0
+# Cloud SQL対応のために追加
+sqlalchemy>=2.0.0
+pg8000>=1.30.0  # PostgreSQL用ドライバー（Cloud SQLでPostgreSQLを使用する場合）
+pymysql>=1.1.0  # MySQL用ドライバー（Cloud SQLでMySQLを使用する場合）


### PR DESCRIPTION
# 更新内容詳細

## 1. `.gitignore` の更新
- **変更点:**
  ```diff
  +/database/__pycache__
  ```
  - `database` モジュールのキャッシュファイルを無視対象に追加。

## 2. `database` モジュールの追加
### 構成ファイルと内容
- **`__init__.py`**
  - データベースパッケージの初期化。
  ```python
  from .db_models import create_tables, VideoSummary
  from .db_service import DatabaseService
  __all__ = ['create_tables', 'VideoSummary', 'DatabaseService']
  ```

- **`db_models.py`**
  - SQLAlchemyを使用してデータベースモデルを定義。
  - **主要な構造:**
    - `VideoSummary` テーブル:
      - 動画のID、タイトル、説明、チャンネル情報、主要トピック、キーワード、アクションアイテムなどを格納。
      - GCSパス (`gcs_path`) を保存し、再利用可能。
  - **テーブル作成関数:**
    ```python
    def create_tables():
        Base.metadata.create_all(bind=engine)
    ```

- **`db_service.py`**
  - データベース操作サービスクラスを実装。
  - **機能:**
    1. 要約データの保存 (`save_summary_to_db`):
       - 要約データを`VideoSummary`テーブルに保存。
    2. 要約データの取得 (`get_summary_by_video_id`):
       - 動画IDに基づき過去の要約データを取得。

## 3. `main.py` の更新
- **新しいインポート:**
  - `database.db_models` から `create_tables`。
  - `database.db_service` から `DatabaseService`。
- **アプリケーション起動時のテーブル作成:**
  ```python
  create_tables()
  ```
- **`get_video_summary` 関数の更新:**
  1. **キャッシュ機能の追加:**
     - DBから既存の要約データを検索、存在する場合はキャッシュを使用。
  2. **要約データの保存:**
     - 新規生成した要約データをDBに保存し、GCSパスも記録。

## 4. `requirements.txt` の更新
- **Cloud SQL対応に伴うパッケージ追加:**
  - SQLAlchemy (`sqlalchemy>=2.0.0`)
  - MySQL用ドライバー (`pymysql>=1.1.0`)
  - PostgreSQL用ドライバー（オプション） (`pg8000>=1.30.0`)

## 5. `README.md` の更新
- **新規セクション追加:**
  1. **データベースとGCSの設定方法:**
     - 必要な環境変数例、Cloud SQL Proxyの設定方法。
  2. **新機能:**
     - **要約データのキャッシュ利用:** DBとGCSを活用。
     - **要約生成の詳細:** GPT-4.1-nanoを使用。
  3. **トラブルシューティング:**
     - Cloud SQL接続エラー、GCS保存エラーの対処方法。

## 6. プロジェクト全体の技術スタック強化
- **バックエンド:**
  - Cloud SQL (MySQL) を導入し、要約データを構造化保存。
  - Google Cloud Storage (GCS) に要約データをJSON形式で保存。
- **フロントエンド:**
  - Docker対応の追加。
